### PR TITLE
RAILS_DEFAULT_LOGGER is deprecated. Using ::Rails.logger

### DIFF
--- a/lib/gapps_openid.rb
+++ b/lib/gapps_openid.rb
@@ -72,7 +72,7 @@ module OpenID
   class GoogleDiscovery
     
     OpenID.cache = RAILS_CACHE rescue nil
-    OpenID.logger = RAILS_DEFAULT_LOGGER rescue nil
+    OpenID.logger = ::Rails.logger rescue nil
     
     NAMESPACES = {
       'xrds' => 'xri://$xrd*($v*2.0)',


### PR DESCRIPTION
This removes a warning when using the gem with newer versions of Rails
